### PR TITLE
Check for NaN values before returning temperature and expose device details to HomeBridge.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const NefitEasyClient = require('nefit-easy-commands');
 var Service, Characteristic;
+var serialNumber;
 
 module.exports = function(homebridge) {
   Service        = homebridge.hap.Service;
@@ -17,6 +18,8 @@ function NefitEasyAccessory(log, config) {
       typeof creds.accessKey !== 'string' || typeof creds.password !== 'string') {
     throw Error('[homebridge-nefit-easy] Invalid/missing credentials in configuration file.');
   }
+
+  serialNumber = creds.serialNumber;
 
   this.service = new Service.Thermostat(this.name);
   this.client  = NefitEasyClient(creds);
@@ -90,5 +93,10 @@ NefitEasyAccessory.prototype.getCurrentState = function(callback) {
 };
 
 NefitEasyAccessory.prototype.getServices = function() {
-  return [ this.service ];
+  const informationService = new Service.AccessoryInformation()
+        .setCharacteristic(Characteristic.Manufacturer, 'Nefit')
+        .setCharacteristic(Characteristic.Model, 'Easy')
+        .setCharacteristic(Characteristic.SerialNumber, serialNumber)
+  
+  return [informationService, this.service];
 };

--- a/index.js
+++ b/index.js
@@ -53,6 +53,9 @@ NefitEasyAccessory.prototype.getTemperature = function(type, prop, callback) {
       this.log.debug('...%s temperature is %s', type, temp);
       return callback(null, temp);
     }
+    else {
+      return callback(new Error("Device returned NaN as temperature value."));
+    }
   }).catch((e) => {
     console.error(e);
     return callback(e);

--- a/index.js
+++ b/index.js
@@ -46,8 +46,10 @@ NefitEasyAccessory.prototype.getTemperature = function(type, prop, callback) {
     return this.client.status(true);
   }).then((status) => {
     var temp = status[prop];
-    this.log.debug('...%s temperature is %s', type, temp);
-    return callback(null, temp);
+    if (!isNaN(temp) && isFinite(temp)) {
+      this.log.debug('...%s temperature is %s', type, temp);
+      return callback(null, temp);
+    }
   }).catch((e) => {
     console.error(e);
     return callback(e);


### PR DESCRIPTION
There seemed to be an issue where  HomeBridge some times complained it received a NaN value from the plugin, this is fixed by checking if the received value from the device API is not NaN before returning it to HomeBridge.

Also the device details (manufacturer, model, and serial number) are now exposed to HomeBridge, so the real details are shown instead of the HomeBridge defaults.