### PR TITLE
Update fix for NaN errors, fix slow down Homebridge warning, implement target state, set characteristic props, add outdoor temperature accessory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ To also use the outdoor temperature measured by the Nefit Easy device, add a `Ne
 * Getting the current temperature
 * Getting the target temperature
 * Setting the target temperature
+* Getting the outside temperature (optional)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Once you have that working, edit `~/.homebridge/config.json` and add a new acces
             "serialNumber" : "NEFIT_SERIAL_NUMBER",
             "accessKey"    : "NEFIT_ACCESS_KEY",
             "password"     : "NEFIT_PASSWORD"
-        }
+        },
+        "outdoorTemp": "enable"
     }
 ]
 ```
@@ -50,6 +51,7 @@ Once you have that working, edit `~/.homebridge/config.json` and add a new acces
 * The `name` will be the identifier that you can use, for example, in Siri commands;
 * Replace `NEFIT_*` with the correct values;
 * Any additional options get passed to the [`nefit-easy-core` constructor](https://github.com/robertklep/nefit-easy-core#constructor).
+* The value of `outdoorTemp` can be either `"enable"` or `"disable"`. This determines if a temperature sensor accessory is added with the outdoor temperature of the Nefit device.
 
 ## Supported actions
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Once you have that working, edit `~/.homebridge/config.json` and add a new acces
             "serialNumber" : "NEFIT_SERIAL_NUMBER",
             "accessKey"    : "NEFIT_ACCESS_KEY",
             "password"     : "NEFIT_PASSWORD"
-        },
-        "outdoorTemp": "enable"
+        }
     }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Once you have that working, edit `~/.homebridge/config.json` and add a new acces
 * The `name` will be the identifier that you can use, for example, in Siri commands;
 * Replace `NEFIT_*` with the correct values;
 * Any additional options get passed to the [`nefit-easy-core` constructor](https://github.com/robertklep/nefit-easy-core#constructor).
-* The value of `outdoorTemp` can be either `"enable"` or `"disable"`. This determines if a temperature sensor accessory is added with the outdoor temperature of the Nefit device.
 
 ### Outdoor temperature
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ CipherString = DEFAULT
 
 ## Configuration
 
+### Thermostat
+
 First, you need a working Homebridge installation.
 
 Once you have that working, edit `~/.homebridge/config.json` and add a new accessory:
@@ -50,6 +52,27 @@ Once you have that working, edit `~/.homebridge/config.json` and add a new acces
 * The `name` will be the identifier that you can use, for example, in Siri commands;
 * Replace `NEFIT_*` with the correct values;
 * Any additional options get passed to the [`nefit-easy-core` constructor](https://github.com/robertklep/nefit-easy-core#constructor).
+
+### Outdoor temperature
+
+To also use the outdoor temperature measured by the Nefit Easy device, add a `NefitEasyOutdoorTemp` accessory to `~/.homebridge/config.json`:
+
+```
+"accessories": [
+    ...
+    {
+        "accessory" : "NefitEasyOutdoorTemp",
+        "name"      : "buitentemperatuur",
+        "options"   : {
+            "serialNumber" : "NEFIT_SERIAL_NUMBER",
+            "accessKey"    : "NEFIT_ACCESS_KEY",
+            "password"     : "NEFIT_PASSWORD"
+        }
+    }
+]
+```
+
+*All credentials options should be set for both the `NefitEasy` and the `NefitEasyOutdoorTemp` device.*
 
 ## Supported actions
 

--- a/index.js
+++ b/index.js
@@ -23,9 +23,14 @@ function NefitEasyAccessory(log, config) {
   this.service = new Service.Thermostat(this.name);
   this.client  = NefitEasyClient(creds);
 
+  // Establish connection with device.
+  this.client.connect().catch((e) => {
+    throw error(e);
+  });
+
   this.service
-      .getCharacteristic(Characteristic.TemperatureDisplayUnits)
-      .on('get', (callback) => callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS));
+    .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+    .on('get', (callback) => callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS));
 
   this.service
     .getCharacteristic(Characteristic.CurrentTemperature)
@@ -98,7 +103,7 @@ NefitEasyAccessory.prototype.getServices = function() {
   const informationService = new Service.AccessoryInformation()
         .setCharacteristic(Characteristic.Manufacturer, 'Nefit')
         .setCharacteristic(Characteristic.Model, 'Easy')
-        .setCharacteristic(Characteristic.SerialNumber, this.serialNumber)
-  
+        .setCharacteristic(Characteristic.SerialNumber, this.serialNumber);
+
   return [informationService, this.service];
 };

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function NefitEasyAccessory(log, config) {
 
   this.service
     .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-    .on('get', this.getCurrentState.bind(this, Characteristic.CurrentHeatingCoolingState.OFF))
+    .on('get', this.getCurrentState.bind(this))
     .setProps(
       {validValues:
         [Characteristic.CurrentHeatingCoolingState.OFF, 
@@ -53,11 +53,10 @@ function NefitEasyAccessory(log, config) {
 
   this.service
     .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-    .on('get', this.getCurrentState.bind(this, Characteristic.TargetHeatingCoolingState.AUTO))
+    .on('get', (callback) => callback(null, Characteristic.TargetHeatingCoolingState.AUTO))
     .setProps(
       {validValues:
-        [Characteristic.TargetHeatingCoolingState.HEAT,
-         Characteristic.TargetHeatingCoolingState.AUTO]
+        [Characteristic.TargetHeatingCoolingState.AUTO]
       });
 };
 
@@ -95,7 +94,7 @@ NefitEasyAccessory.prototype.setTemperature = function(temp, callback) {
   });
 };
 
-NefitEasyAccessory.prototype.getCurrentState = function(offState, callback) {
+NefitEasyAccessory.prototype.getCurrentState = function(callback) {
   this.log.debug('Getting current state..');
 
   this.client.connect().then(() => {
@@ -106,7 +105,7 @@ NefitEasyAccessory.prototype.getCurrentState = function(offState, callback) {
     this.log.debug('...current state is', state);
     return callback(null,
       isHeating ? Characteristic.CurrentHeatingCoolingState.HEAT :
-                  offState
+                  Characteristic.CurrentHeatingCoolingState.OFF
     );
   }).catch((e) => {
     console.error(e);

--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ function NefitEasyAccessory(log, config) {
   this.service
     .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
     .on('get', this.getCurrentState.bind(this));
+
+  this.service
+    .getCharacteristic(Characteristic.TargetHeatingCoolingState)
+    .on('get', this.getCurrentState.bind(this));
 };
 
 NefitEasyAccessory.prototype.getTemperature = function(type, prop, callback) {

--- a/index.js
+++ b/index.js
@@ -28,11 +28,6 @@ function NefitEasyAccessory(log, config) {
     throw error(e);
   });
 
-  this.service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).props.validValues =
-    [Characteristic.CurrentHeatingCoolingState.OFF, Characteristic.CurrentHeatingCoolingState.HEAT];
-  this.service.getCharacteristic(Characteristic.TargetHeatingCoolingState).props.validValues =
-    [Characteristic.CurrentHeatingCoolingState.HEAT, Characteristic.TargetHeatingCoolingState.AUTO];
-
   this.service
     .getCharacteristic(Characteristic.TemperatureDisplayUnits)
     .on('get', (callback) => callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS));
@@ -44,15 +39,26 @@ function NefitEasyAccessory(log, config) {
   this.service
     .getCharacteristic(Characteristic.TargetTemperature)
     .on('get', this.getTemperature.bind(this, 'target', 'temp setpoint'))
-    .on('set', this.setTemperature.bind(this));
+    .on('set', this.setTemperature.bind(this))
+    .setProps({maxValue: 30});
 
   this.service
     .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-    .on('get', this.getCurrentState.bind(this, Characteristic.CurrentHeatingCoolingState.OFF));
+    .on('get', this.getCurrentState.bind(this, Characteristic.CurrentHeatingCoolingState.OFF))
+    .setProps(
+      {validValues: 
+        [Characteristic.CurrentHeatingCoolingState.OFF, 
+         Characteristic.CurrentHeatingCoolingState.HEAT]
+      });
 
   this.service
     .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-    .on('get', this.getCurrentState.bind(this, Characteristic.TargetHeatingCoolingState.AUTO));
+    .on('get', this.getCurrentState.bind(this, Characteristic.TargetHeatingCoolingState.AUTO))
+    .setProps(
+      {validValues:
+        [Characteristic.TargetHeatingCoolingState.HEAT,
+         Characteristic.TargetHeatingCoolingState.AUTO]
+      });
 };
 
 NefitEasyAccessory.prototype.getTemperature = function(type, prop, callback) {

--- a/index.js
+++ b/index.js
@@ -31,9 +31,11 @@ function NefitEasyAccessory(log, config) {
   }
 
   this.serialNumber = creds.serialNumber;
-
   this.service = new Service.Thermostat(this.name);
-  deviceClient  = NefitEasyClient(creds);
+  
+  if (typeof deviceClient === 'undefined') {
+    deviceClient  = NefitEasyClient(creds);
+  }
 
   // Establish connection with device.
   deviceClient.connect().catch((e) => {
@@ -152,9 +154,11 @@ function NefitEasyAccessoryOutdoorTemp(log, config) {
   }
 
   this.serialNumber = creds.serialNumber;
-
   this.service = new Service.TemperatureSensor(this.name);
-  deviceClient  = NefitEasyClient(creds);
+
+  if (typeof deviceClient === 'undefined') {
+    deviceClient  = NefitEasyClient(creds);
+  }
 
   // Establish connection with device.
   deviceClient.connect().catch((e) => {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ function NefitEasyAccessory(log, config) {
   this.serialNumber = creds.serialNumber;
 
   this.thermostatService = new Service.Thermostat(this.name);
-  this.outdoorTempService = new Service.TemperatureSensor(this.name + " outdoor temp");
   this.client  = NefitEasyClient(creds);
 
   // Establish connection with device.
@@ -61,9 +60,13 @@ function NefitEasyAccessory(log, config) {
         [Characteristic.TargetHeatingCoolingState.AUTO]
       });
 
-  this.outdoorTempService
-    .getCharacteristic(Characteristic.CurrentTemperature)
-    .on('get', this.getTemperature.bind(this, 'outdoor', 'outdoor temp', false));
+  if (!(typeof config.outdoorTemp == 'string' && config.outdoorTemp == 'disable')) {
+    this.outdoorTempService = new Service.TemperatureSensor(this.name + " outdoor temp");
+    
+    this.outdoorTempService
+      .getCharacteristic(Characteristic.CurrentTemperature)
+      .on('get', this.getTemperature.bind(this, 'outdoor', 'outdoor temp', false));
+    }
 };
 
 NefitEasyAccessory.prototype.getTemperature = function(type, prop, skipOutdoor, callback) {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ function NefitEasyAccessory(log, config) {
     throw error(e);
   });
 
+  this.service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).props.validValues =
+    [Characteristic.CurrentHeatingCoolingState.OFF, Characteristic.CurrentHeatingCoolingState.HEAT];
+  this.service.getCharacteristic(Characteristic.TargetHeatingCoolingState).props.validValues =
+    [Characteristic.CurrentHeatingCoolingState.HEAT, Characteristic.TargetHeatingCoolingState.AUTO];
+
   this.service
     .getCharacteristic(Characteristic.TemperatureDisplayUnits)
     .on('get', (callback) => callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS));
@@ -43,11 +48,11 @@ function NefitEasyAccessory(log, config) {
 
   this.service
     .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-    .on('get', this.getCurrentState.bind(this));
+    .on('get', this.getCurrentState.bind(this, Characteristic.CurrentHeatingCoolingState.OFF));
 
   this.service
     .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-    .on('get', this.getCurrentState.bind(this));
+    .on('get', this.getCurrentState.bind(this, Characteristic.TargetHeatingCoolingState.AUTO));
 };
 
 NefitEasyAccessory.prototype.getTemperature = function(type, prop, callback) {
@@ -84,7 +89,7 @@ NefitEasyAccessory.prototype.setTemperature = function(temp, callback) {
   });
 };
 
-NefitEasyAccessory.prototype.getCurrentState = function(callback) {
+NefitEasyAccessory.prototype.getCurrentState = function(offState, callback) {
   this.log.debug('Getting current state..');
 
   this.client.connect().then(() => {
@@ -95,7 +100,7 @@ NefitEasyAccessory.prototype.getCurrentState = function(callback) {
     this.log.debug('...current state is', state);
     return callback(null,
       isHeating ? Characteristic.CurrentHeatingCoolingState.HEAT :
-                  Characteristic.CurrentHeatingCoolingState.OFF
+                  offState
     );
   }).catch((e) => {
     console.error(e);

--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ function NefitEasyAccessory(log, config) {
 
   this.service
     .getCharacteristic(Characteristic.TemperatureDisplayUnits)
-    .on('get', (callback) => callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS));
+    .on('get', (callback) => callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS))
+    .setProps({validValues: [Characteristic.TemperatureDisplayUnits.CELSIUS]});;
 
   this.service
     .getCharacteristic(Characteristic.CurrentTemperature)
@@ -57,18 +58,14 @@ function NefitEasyAccessory(log, config) {
     .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
     .on('get', this.getCurrentState.bind(this))
     .setProps(
-      {validValues:
-        [Characteristic.CurrentHeatingCoolingState.OFF, 
-         Characteristic.CurrentHeatingCoolingState.HEAT]
+      {validValues: [Characteristic.CurrentHeatingCoolingState.OFF, 
+                     Characteristic.CurrentHeatingCoolingState.HEAT]
       });
 
   this.service
     .getCharacteristic(Characteristic.TargetHeatingCoolingState)
     .on('get', (callback) => callback(null, Characteristic.TargetHeatingCoolingState.AUTO))
-    .setProps(
-      {validValues:
-        [Characteristic.TargetHeatingCoolingState.AUTO]
-      });
+    .setProps({validValues: [Characteristic.TargetHeatingCoolingState.AUTO]});
 };
 
 const nefitEasyGetTemp = function(type, prop, skipOutdoor, callback) {
@@ -83,7 +80,8 @@ const nefitEasyGetTemp = function(type, prop, skipOutdoor, callback) {
       return callback(null, temp);
     }
     else {
-      // Return previous value if the device returns NaN.
+      // Return last known value if the device returns NaN.
+      // This is needed to keep the service responsive.
       if (prop == 'in house temp' || prop == 'outdoor temp') {
         temp = this.service.getCharacteristic(Characteristic.CurrentTemperature).value;
       }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Service, Characteristic;
 module.exports = function(homebridge) {
   Service        = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
-  
+
   homebridge.registerAccessory('homebridge-nefit-easy', 'NefitEasy', NefitEasyAccessory);
   homebridge.registerAccessory('homebridge-nefit-easy', 'NefitEasyOutdoorTemp', NefitEasyAccessoryOutdoorTemp);
 };
@@ -83,7 +83,14 @@ const nefitEasyGetTemp = function(type, prop, skipOutdoor, callback) {
       return callback(null, temp);
     }
     else {
-      return callback(new Error("Device returned NaN as temperature value."));
+      // Return previous value if the device returns NaN.
+      if (prop == 'in house temp' || prop == 'outdoor temp') {
+        temp = this.service.getCharacteristic(Characteristic.CurrentTemperature).value;
+      }
+      else {
+        temp = this.service.getCharacteristic(Characteristic.TargetTemperature).value;
+      }
+      return callback(null, temp);
     }
   }).catch((e) => {
     console.error(e);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const NefitEasyClient = require('nefit-easy-commands');
 var Service, Characteristic;
-var serialNumber;
 
 module.exports = function(homebridge) {
   Service        = homebridge.hap.Service;
@@ -19,7 +18,7 @@ function NefitEasyAccessory(log, config) {
     throw Error('[homebridge-nefit-easy] Invalid/missing credentials in configuration file.');
   }
 
-  serialNumber = creds.serialNumber;
+  this.serialNumber = creds.serialNumber;
 
   this.service = new Service.Thermostat(this.name);
   this.client  = NefitEasyClient(creds);
@@ -99,7 +98,7 @@ NefitEasyAccessory.prototype.getServices = function() {
   const informationService = new Service.AccessoryInformation()
         .setCharacteristic(Characteristic.Manufacturer, 'Nefit')
         .setCharacteristic(Characteristic.Model, 'Easy')
-        .setCharacteristic(Characteristic.SerialNumber, serialNumber)
+        .setCharacteristic(Characteristic.SerialNumber, this.serialNumber)
   
   return [informationService, this.service];
 };

--- a/index.js
+++ b/index.js
@@ -40,13 +40,13 @@ function NefitEasyAccessory(log, config) {
     .getCharacteristic(Characteristic.TargetTemperature)
     .on('get', this.getTemperature.bind(this, 'target', 'temp setpoint'))
     .on('set', this.setTemperature.bind(this))
-    .setProps({maxValue: 30});
+    .setProps({minValue: 5, maxValue: 30, minStep: 0.5});
 
   this.service
     .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
     .on('get', this.getCurrentState.bind(this, Characteristic.CurrentHeatingCoolingState.OFF))
     .setProps(
-      {validValues: 
+      {validValues:
         [Characteristic.CurrentHeatingCoolingState.OFF, 
          Characteristic.CurrentHeatingCoolingState.HEAT]
       });

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function NefitEasyAccessory(log, config) {
     .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
     .on('get', this.getCurrentState.bind(this))
     .setProps(
-      {validValues: [Characteristic.CurrentHeatingCoolingState.OFF, 
+      {validValues: [Characteristic.CurrentHeatingCoolingState.OFF,
                      Characteristic.CurrentHeatingCoolingState.HEAT]
       });
 

--- a/index.js
+++ b/index.js
@@ -71,9 +71,7 @@ function NefitEasyAccessory(log, config) {
 const nefitEasyGetTemp = function(type, prop, skipOutdoor, callback) {
   this.log.debug('Getting %s temperature...', type);
 
-  this.client.connect().then(() => {
-    return this.client.status(skipOutdoor);
-  }).then((status) => {
+  this.client.status(skipOutdoor).then((status) => {
     var temp = status[prop];
     if (!isNaN(temp) && isFinite(temp)) {
       this.log.debug('...%s temperature is %s', type, temp);
@@ -115,9 +113,7 @@ NefitEasyAccessory.prototype.setTemperature = function(temp, callback) {
   temp = Math.round(temp * 2) / 2;
 
   this.log.info('Setting temperature to %s', temp);
-  this.client.connect().then(() => {
-    return this.client.setTemperature(temp);
-  }).then(() => {
+  this.client.setTemperature(temp).then(() => {
     return callback();
   }).catch((e) => {
     return callback(e);
@@ -127,9 +123,7 @@ NefitEasyAccessory.prototype.setTemperature = function(temp, callback) {
 NefitEasyAccessory.prototype.getCurrentState = function(callback) {
   this.log.debug('Getting current state..');
 
-  this.client.connect().then(() => {
-    return this.client.status();
-  }).then((status) => {
+  this.client.status(true).then((status) => {
     var state     = status['boiler indicator'];
     var isHeating = state === 'central heating';
     this.log.debug('...current state is', state);


### PR DESCRIPTION
- When the device returns NaN as a temperature value the plugin now requests the temperature from the device one more time. This almost always results in a valid value. When the value is still NaN after retrying, the previously known value is returned, this was already the case when the NaN warning was generated and this ensures the device stays responsive.
- Homebridge gave warnings about the plugin slowing down Homebridge on startup (`This plugin slows down Homebridge. The read handler for the characteristic ... was slow to respond!`). This has been resolved by creating the connection with the device when the plugin starts, instead of when the first request is made.
- The `TargetHeatingCoolingState` characteristic has been implemented and always returns AUTO, since this is the only target state the Nefit Easy device supports.
- The `validValues`, `minValue`, `maxValue`, and `minStep` properties of the characteristics have been set correctly according to their desired behaviour.
- The outdoor temperature from the Nefit Easy device can now be added as an extra accessory. For this a new accessory needs to be added in the Homebridge config. A section about this has been added to README.md.